### PR TITLE
Excluding properties from index

### DIFF
--- a/udatastore/_version.py
+++ b/udatastore/_version.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 
-__version__ = '0.1.5'
+__version__ = '0.1.6'

--- a/udatastore/document.py
+++ b/udatastore/document.py
@@ -62,10 +62,10 @@ class DataStoreDocument(DocumentImplementation):
                     doc.io_validate(validate_all=io_validate_all)
                     payloads.append(doc._data.to_mongo(update=False))
 
-            keys = cls.collection.put_multi(
+            keys = cls.collection.put_multi(  # pylint: disable=E1101
                 payloads,
                 exclude_from_indexes=cls.excluded_properties()
-            )  # pylint: disable=E1101
+            )
 
             for key, doc in zip(keys, docs):
                 if not doc.is_created:

--- a/udatastore/document.py
+++ b/udatastore/document.py
@@ -27,6 +27,10 @@ class DataStoreDocument(DocumentImplementation):
 
     opts = DocumentImplementation.opts
 
+    @staticmethod
+    def excluded_properties():
+        return ()
+
     def reload(self):
         """
         Retrieve and replace document's data by the ones in database.
@@ -58,7 +62,7 @@ class DataStoreDocument(DocumentImplementation):
                     doc.io_validate(validate_all=io_validate_all)
                     payloads.append(doc._data.to_mongo(update=False))
 
-            keys = cls.collection.put_multi(payloads)  # pylint: disable=E1101
+            keys = cls.collection.put_multi(payloads, cls.excluded_properties())  # pylint: disable=E1101
 
             for key, doc in zip(keys, docs):
                 if not doc.is_created:

--- a/udatastore/helpers.py
+++ b/udatastore/helpers.py
@@ -92,11 +92,11 @@ class CollectionAbstraction:
             payload[key] = value
         return payload
 
-    def _pack(self, payload):
+    def _pack(self, payload, exclude_from_indexes=()):
         ref = payload.pop('_id', None)
         if not isinstance(ref, datastore.Key):
             ref = self.key(ref)
-        entity = datastore.Entity(key=ref)
+        entity = datastore.Entity(key=ref, exclude_from_indexes=exclude_from_indexes)
         entity.update(payload)
         return entity
 
@@ -115,12 +115,12 @@ class CollectionAbstraction:
         entity_map = {e.key.id_or_name: e for e in entities}
         return [self._unpack(entity_map.get(key, None)) for key in keys]
 
-    def put(self, payload):
-        keys = self.put_multi([payload])
+    def put(self, payload, *args, **kwargs):
+        keys = self.put_multi([payload], *args, **kwargs)
         return keys[0]
 
-    def put_multi(self, payloads):
-        entities = list(map(self._pack, payloads))
+    def put_multi(self, payloads, exclude_from_indexes=()):
+        entities = list(map(lambda p: self._pack(p, exclude_from_indexes), payloads))
         self.client.put_multi(entities)
         return list(map(lambda k: k.key, entities))
 


### PR DESCRIPTION
We did not have anything to exclude a property from the datastore index. Ideally, this would be implemented through the fields but this would involve a lot of hacks I'm afraid. I added a method in the document returning a tuple listing the properties to be excluded. These are passed to the `collection._pack` method.